### PR TITLE
Switch to PS singleton pattern using 'new class'

### DIFF
--- a/src/natures.ts
+++ b/src/natures.ts
@@ -83,14 +83,14 @@ const NATURES: Readonly<{ [id: string]: Nature }> = {
   timid: new NatureImpl('Timid', { plus: 'spe', minus: 'atk' }),
 };
 
-export const Natures = {
+export const Natures = new (class {
   get(id: ID): Nature | undefined {
     return NATURES[id];
-  },
+  }
 
   *[Symbol.iterator](): IterableIterator<Nature> {
     for (const id in NATURES) {
       yield NATURES[id];
     }
-  },
-};
+  }
+})();

--- a/tslint.json
+++ b/tslint.json
@@ -4,7 +4,6 @@
   ],
   "rules": {
     "forin": false,
-    "new-parens": false,
     "no-any": false,
     "prefer-const": {
       "options": {


### PR DESCRIPTION
I was reading over some of the [newer PS code](https://github.com/Zarel/Pokemon-Showdown-Client/blob/master/src/client-main.ts) and remembered we were using `new class { ... }` for singletons. This removes the need for the weird method overloading workaround, but unfortunately even with `"new-parens": false` prettier still won't allow us to format it the more magical way that PS uses, so I removed the tslint rule because that was the whole reason it was disabled in the first place.