### PR TITLE
build & loading code

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/Pokemon-Showdown"]
+	path = vendor/Pokemon-Showdown
+	url = git://github.com/monsanto/Pokemon-Showdown.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/Pokemon-Showdown"]
 	path = vendor/Pokemon-Showdown
-	url = git://github.com/monsanto/Pokemon-Showdown.git
+	url = git://github.com/Zarel/Pokemon-Showdown.git

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "posttest": "npm run lint",
     "build": "tsc && tslint --project . -c tslint-semantic.json",
     "fullbuild": "npm run compile && npm run lint",
-    "import": "node build/tools/convert-ps-data.js vendor/Pokemon-Showdown build/data"
+    "import": "node build/tools/convert-ps-data.js vendor/Pokemon-Showdown/data build/data"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "gts": "^1.1.0",
     "jest": "^24.9.0",
     "json-stringify-deterministic": "^1.0.1",
-    "mkdirp": "^0.5.1",
     "source-map-support": "^0.5.13",
     "ts-jest": "^24.1.0",
     "typescript": "^3.6.4"
@@ -38,6 +37,6 @@
     "posttest": "npm run lint",
     "build": "tsc && tslint --project . -c tslint-semantic.json",
     "fullbuild": "npm run compile && npm run lint",
-    "convert-ps-data": "mkdirp build/data && node build/tools/convert-ps-data.js vendor/Pokemon-Showdown build/data"
+    "import": "node build/tools/convert-ps-data.js vendor/Pokemon-Showdown build/data"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "@types/jest": "^24.0.19",
     "gts": "^1.1.0",
     "jest": "^24.9.0",
+    "json-stringify-deterministic": "^1.0.1",
+    "mkdirp": "^0.5.1",
     "source-map-support": "^0.5.13",
     "ts-jest": "^24.1.0",
     "typescript": "^3.6.4"
@@ -35,6 +37,7 @@
     "pretest": "npm run compile",
     "posttest": "npm run lint",
     "build": "tsc && tslint --project . -c tslint-semantic.json",
-    "fullbuild": "npm run compile && npm run lint"
+    "fullbuild": "npm run compile && npm run lint",
+    "convert-ps-data": "mkdirp build/data && node build/tools/convert-ps-data.js vendor/Pokemon-Showdown build/data"
   }
 }

--- a/src/dex-interfaces.ts
+++ b/src/dex-interfaces.ts
@@ -1,0 +1,46 @@
+import { GenerationNumber } from './gens';
+
+// Plain interface
+
+export interface PlainDex {
+  gens: PlainGeneration[];
+}
+
+export interface PlainGeneration {
+  num: GenerationNumber;
+  species: PlainSpecies[];
+}
+
+export interface PlainGameObject {
+  name: string;
+}
+
+export interface PlainSpecies extends PlainGameObject {
+  prevo: number | null;
+  evos: number[];
+}
+
+// Rich interface
+
+export interface Store<T> {
+  [Symbol.iterator](): Iterator<T>;
+}
+
+export interface Dex {
+  gens: Store<Generation>;
+}
+
+export interface Generation {
+  num: GenerationNumber;
+  species: Store<Species>;
+}
+
+export interface GameObject {
+  gen: Generation;
+  name: string;
+}
+
+export interface Species extends GameObject {
+  prevo: Species | null;
+  evos: Species[];
+}

--- a/src/dex-lazy-impl.ts
+++ b/src/dex-lazy-impl.ts
@@ -2,11 +2,9 @@ import * as I from './dex-interfaces';
 
 class Transformer<Src, Dest> implements I.Store<Dest> {
   constructor(
-    _source: Src[],
-    _fn: (dv: Src) => Dest,
-    private source = _source,
-    private fn = _fn,
-    private cache = new Array(_source.length)
+    private source: Src[],
+    private fn: (dv: Src) => Dest,
+    private cache = new Array(source.length)
   ) {}
 
   get(id: number) {
@@ -66,9 +64,8 @@ class Generation implements I.Generation {
 
 class Species implements I.Species {
   constructor(
-    _gen: Generation,
+    public gen: Generation,
     specie: I.PlainSpecies,
-    public gen = _gen,
     public name = specie.name,
     private _prevo = specie.prevo,
     private _evos = specie.evos

--- a/src/dex-lazy-impl.ts
+++ b/src/dex-lazy-impl.ts
@@ -1,0 +1,85 @@
+import * as I from './dex-interfaces';
+
+class Transformer<Src, Dest> implements I.Store<Dest> {
+  constructor(
+    _source: Src[],
+    _fn: (dv: Src) => Dest,
+    private source = _source,
+    private fn = _fn,
+    private cache = new Array(_source.length)
+  ) {}
+
+  get(id: number) {
+    let v = this.cache[id];
+    if (v !== undefined) {
+      return v;
+    }
+
+    const dv = this.source[id];
+    if (dv === undefined) {
+      return undefined;
+    }
+
+    v = this.fn(dv);
+    this.cache[id] = v;
+    return v;
+  }
+
+  resolve(id: number): Dest {
+    const v = this.get(id);
+    if (v === undefined) {
+      throw new Error('Cannot resolve');
+    }
+    return v;
+  }
+
+  *[Symbol.iterator]() {
+    for (let i = 0; i < this.source.length; i++) {
+      let v = this.cache[i];
+      if (v === undefined) {
+        const dv = this.source[i];
+        v = this.fn(dv);
+        this.cache[i] = v;
+      }
+      yield v;
+    }
+  }
+}
+
+export default class Dex implements I.Dex {
+  constructor(
+    _source: I.PlainDex,
+    public gens = new Transformer(_source.gens, (gen: I.PlainGeneration) => new Generation(gen))
+  ) {}
+}
+
+class Generation implements I.Generation {
+  constructor(
+    _source: I.PlainGeneration,
+    public num = _source.num,
+    public species = new Transformer(
+      _source.species,
+      (specie: I.PlainSpecies) => new Species(this, specie)
+    )
+  ) {}
+}
+
+class Species implements I.Species {
+  constructor(
+    _gen: Generation,
+    specie: I.PlainSpecies,
+    public gen = _gen,
+    public name = specie.name,
+    private _prevo = specie.prevo,
+    private _evos = specie.evos
+  ) {}
+
+  get prevo() {
+    if (this._prevo === null) return null;
+    return this.gen.species.resolve(this._prevo);
+  }
+
+  get evos() {
+    return this._evos.map(id => this.gen.species.resolve(id));
+  }
+}

--- a/src/gens.ts
+++ b/src/gens.ts
@@ -1,1 +1,3 @@
 export type GenerationNumber = 1 | 2 | 3 | 4 | 5 | 6 | 7;
+
+export const GENERATIONS: Readonly<GenerationNumber[]> = [1, 2, 3, 4, 5, 6, 7];

--- a/src/gens.ts
+++ b/src/gens.ts
@@ -1,3 +1,3 @@
 export type GenerationNumber = 1 | 2 | 3 | 4 | 5 | 6 | 7;
 
-export const GENERATIONS: Readonly<GenerationNumber[]> = [1, 2, 3, 4, 5, 6, 7];
+export const GENERATIONS: readonly GenerationNumber[] = [1, 2, 3, 4, 5, 6, 7];

--- a/src/ps-import.ts
+++ b/src/ps-import.ts
@@ -19,11 +19,9 @@ type PSDex = Record<GenerationNumber, Record<DataKind, IDMap>>;
 // Loading
 ////////////////////////////////////////////////////////////////////////////////
 
-function requireMap(psDir: string, gen: GenerationNumber, name: string, key?: string): IDMap {
-  const dirComponents = [process.cwd(), psDir];
-  if (gen === 7) {
-    dirComponents.push(`data`);
-  } else {
+function requireMap(psDataDir: string, gen: GenerationNumber, name: string, key?: string): IDMap {
+  const dirComponents = [process.cwd(), psDataDir];
+  if (gen !== 7) {
     dirComponents.push('mods', `gen${gen}`);
   }
 
@@ -32,7 +30,7 @@ function requireMap(psDir: string, gen: GenerationNumber, name: string, key?: st
   // least see if the directory exists.
 
   if (!fs.existsSync(dir)) {
-    throw new Error(`Directory ${psDir} doesn't exist`);
+    throw new Error(`Directory ${psDataDir} doesn't exist`);
   }
 
   const filename = path.join(dir, name);
@@ -62,11 +60,14 @@ function mergeMap(map1: IDMap, map2: IDMap) {
   return map1;
 }
 
-function requirePSDex(psDir: string) {
+function requirePSDex(psDataDir: string) {
   const dex = {} as PSDex;
   for (const gen of GENERATIONS) {
     dex[gen] = {
-      species: mergeMap(requireMap(psDir, gen, 'pokedex'), requireMap(psDir, gen, 'formats-data')),
+      species: mergeMap(
+        requireMap(psDataDir, gen, 'pokedex'),
+        requireMap(psDataDir, gen, 'formats-data')
+      ),
     };
   }
 
@@ -116,28 +117,28 @@ function isMega(s: any) {
   return ['Mega', 'Mega-X', 'Mega-Y', 'Primal'].includes(s.forme);
 }
 
-function isAlola(s: any) {
-  return s.forme !== undefined && s.forme.startsWith('Alola');
+function isAlolaOrStarter(s: any) {
+  return s.forme !== undefined && (s.forme.startsWith('Alola') || s.forme === 'Starter');
 }
 
 const PREDS = {
   1: {
-    species: (s: any) => 1 <= s.num && s.num <= 151 && !isMega(s) && !isAlola(s),
+    species: (s: any) => 1 <= s.num && s.num <= 151 && !isMega(s) && !isAlolaOrStarter(s),
   },
   2: {
-    species: (s: any) => 1 <= s.num && s.num <= 251 && !isMega(s) && !isAlola(s),
+    species: (s: any) => 1 <= s.num && s.num <= 251 && !isMega(s) && !isAlolaOrStarter(s),
   },
   3: {
-    species: (s: any) => 1 <= s.num && s.num <= 386 && !isMega(s) && !isAlola(s),
+    species: (s: any) => 1 <= s.num && s.num <= 386 && !isMega(s) && !isAlolaOrStarter(s),
   },
   4: {
-    species: (s: any) => 1 <= s.num && s.num <= 493 && !isMega(s) && !isAlola(s),
+    species: (s: any) => 1 <= s.num && s.num <= 493 && !isMega(s) && !isAlolaOrStarter(s),
   },
   5: {
-    species: (s: any) => 1 <= s.num && s.num <= 649 && !isMega(s) && !isAlola(s),
+    species: (s: any) => 1 <= s.num && s.num <= 649 && !isMega(s) && !isAlolaOrStarter(s),
   },
   6: {
-    species: (s: any) => 1 <= s.num && s.num <= 721 && !isAlola(s),
+    species: (s: any) => 1 <= s.num && s.num <= 721 && !isAlolaOrStarter(s),
   },
   7: {
     species: (s: any) => 1 <= s.num,
@@ -216,8 +217,8 @@ function transformPSDex(dexIn: PSDex): Dex.PlainDex {
 // Putting it all together...
 ////////////////////////////////////////////////////////////////////////////////
 
-export default function(psDir: string): Dex.PlainDex {
-  const dexIn = requirePSDex(psDir);
+export default function(psDataDir: string): Dex.PlainDex {
+  const dexIn = requirePSDex(psDataDir);
   inheritPSDex(dexIn);
   filterPSDex(dexIn);
   const dexOut = transformPSDex(dexIn);

--- a/src/ps-import.ts
+++ b/src/ps-import.ts
@@ -1,0 +1,225 @@
+import { toID } from './common';
+import { GenerationNumber, GENERATIONS } from './gens';
+import path from 'path';
+import fs from 'fs';
+import * as Dex from './dex-interfaces';
+
+////////////////////////////////////////////////////////////////////////////////
+// Fundamental types
+////////////////////////////////////////////////////////////////////////////////
+
+type DataKind = 'species';
+const DATAKINDS: Readonly<DataKind[]> = ['species'];
+
+// This is generally an ID map, but in the case of types, it isn't
+type IDMap = Record<string, any>;
+type PSDex = Record<GenerationNumber, Record<DataKind, IDMap>>;
+
+////////////////////////////////////////////////////////////////////////////////
+// Loading
+////////////////////////////////////////////////////////////////////////////////
+
+function requireMap(psDir: string, gen: GenerationNumber, name: string, key?: string): IDMap {
+  const dirComponents = [process.cwd(), psDir];
+  if (gen === 7) {
+    dirComponents.push(`data`);
+  } else {
+    dirComponents.push('mods', `gen${gen}`);
+  }
+
+  const dir = path.resolve(...dirComponents);
+  // We will return {} if we can't find the module file, so as a sanity check, at
+  // least see if the directory exists.
+
+  if (!fs.existsSync(dir)) {
+    throw new Error(`Directory ${psDir} doesn't exist`);
+  }
+
+  const filename = path.join(dir, name);
+
+  try {
+    const mod = require(filename);
+    if (key !== undefined) {
+      return mod[key];
+    } else {
+      const vs = Object.values(mod);
+      if (vs.length === 1) {
+        return vs[0] as IDMap;
+      } else {
+        throw new Error('More than 1 export');
+      }
+    }
+  } catch (e) {
+    return {};
+  }
+}
+
+function mergeMap(map1: IDMap, map2: IDMap) {
+  for (const id in map2) {
+    if (map1[id] === undefined) map1[id] = {};
+    Object.assign(map1[id], map2[id]);
+  }
+  return map1;
+}
+
+function requirePSDex(psDir: string) {
+  const dex = {} as PSDex;
+  for (const gen of GENERATIONS) {
+    dex[gen] = {
+      species: mergeMap(requireMap(psDir, gen, 'pokedex'), requireMap(psDir, gen, 'formats-data')),
+    };
+  }
+
+  return dex;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Inheritance
+////////////////////////////////////////////////////////////////////////////////
+
+function inheritMap(mapFrom: IDMap, mapTo: IDMap) {
+  for (const id in mapFrom) {
+    const objFrom = mapFrom[id];
+    let objTo = mapTo[id];
+    if (!objTo) {
+      objTo = mapTo[id] = { inherit: true };
+    }
+    if (objTo.inherit) {
+      delete objTo.inherit;
+      Object.assign(objTo, { ...objFrom, ...objTo });
+    }
+  }
+}
+
+// pairs([A, B, C]) = [{from: A, to: B}, {from: B, to: C}]
+function* pairs<T>(array: T[]) {
+  for (let i = 0; i < array.length - 1; i++) {
+    yield { from: array[i], to: array[i + 1] };
+  }
+}
+
+function inheritPSDex(dex: PSDex) {
+  for (const { from: genFrom, to: genTo } of pairs(Array.from(GENERATIONS).reverse())) {
+    for (const k of DATAKINDS) {
+      inheritMap(dex[genFrom][k], dex[genTo][k]);
+    }
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Filtering
+////////////////////////////////////////////////////////////////////////////////
+
+// Limits from sim/dex-data.ts
+
+function isMega(s: any) {
+  return ['Mega', 'Mega-X', 'Mega-Y', 'Primal'].includes(s.forme);
+}
+
+function isAlola(s: any) {
+  return s.forme !== undefined && s.forme.startsWith('Alola');
+}
+
+const PREDS = {
+  1: {
+    species: (s: any) => 1 <= s.num && s.num <= 151 && !isMega(s) && !isAlola(s),
+  },
+  2: {
+    species: (s: any) => 1 <= s.num && s.num <= 251 && !isMega(s) && !isAlola(s),
+  },
+  3: {
+    species: (s: any) => 1 <= s.num && s.num <= 386 && !isMega(s) && !isAlola(s),
+  },
+  4: {
+    species: (s: any) => 1 <= s.num && s.num <= 493 && !isMega(s) && !isAlola(s),
+  },
+  5: {
+    species: (s: any) => 1 <= s.num && s.num <= 649 && !isMega(s) && !isAlola(s),
+  },
+  6: {
+    species: (s: any) => 1 <= s.num && s.num <= 721 && !isAlola(s),
+  },
+  7: {
+    species: (s: any) => 1 <= s.num,
+  },
+};
+
+function filterPSDex(dex: PSDex) {
+  for (const gen of GENERATIONS) {
+    for (const k of DATAKINDS) {
+      const map = dex[gen][k];
+      for (const id in dex[gen][k]) {
+        const obj = map[id];
+        if ((obj.gen !== undefined && obj.gen !== gen) || !PREDS[gen][k](obj)) {
+          delete map[id];
+        }
+      }
+    }
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Species
+////////////////////////////////////////////////////////////////////////////////
+
+function transformSpecies(speciesIn: IDMap): Dex.PlainSpecies[] {
+  const speciesOut: Dex.PlainSpecies[] = [];
+  const speciesMap: Map<string, number> = new Map();
+
+  let i = 0;
+  for (const id in speciesIn) {
+    speciesMap.set(id, i);
+    i++;
+  }
+
+  for (const [id, specieIn] of Object.entries(speciesIn)) {
+    const specieOut: Dex.PlainSpecies = {
+      name: specieIn.species,
+      prevo: null,
+      evos: [],
+    };
+
+    const prevoId = speciesMap.get(specieIn.prevo);
+    if (prevoId !== undefined) {
+      specieOut.prevo = prevoId;
+    }
+
+    if (specieIn.evos !== undefined) {
+      for (const evo of specieIn.evos) {
+        const evoId = speciesMap.get(evo);
+        if (evoId !== undefined) {
+          specieOut.evos.push(evo.species);
+        }
+      }
+    }
+
+    speciesOut.push(specieOut);
+  }
+
+  return speciesOut;
+}
+
+function transformPSDex(dexIn: PSDex): Dex.PlainDex {
+  const dexOut: Dex.PlainDex = { gens: [] };
+  for (const gen of GENERATIONS) {
+    const genIn = dexIn[gen];
+    const genOut = {
+      num: gen,
+      species: transformSpecies(genIn.species),
+    };
+    dexOut.gens[gen] = genOut;
+  }
+  return dexOut;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Putting it all together...
+////////////////////////////////////////////////////////////////////////////////
+
+export default function(psDir: string): Dex.PlainDex {
+  const dexIn = requirePSDex(psDir);
+  inheritPSDex(dexIn);
+  filterPSDex(dexIn);
+  const dexOut = transformPSDex(dexIn);
+  return dexOut;
+}

--- a/src/test/dex-lazy-impl.test.ts
+++ b/src/test/dex-lazy-impl.test.ts
@@ -1,0 +1,39 @@
+import * as I from '../dex-interfaces';
+import Dex from '../dex-lazy-impl';
+
+describe('lazy impl', () => {
+  const dexSrc: I.PlainDex = {
+    gens: [
+      {
+        num: 1,
+        species: [
+          {
+            name: 'Charmander',
+            prevo: null,
+            evos: [1],
+          },
+          {
+            name: 'Charmeleon',
+            prevo: 0,
+            evos: [2],
+          },
+          {
+            name: 'Charizard',
+            prevo: 1,
+            evos: [],
+          },
+        ],
+      },
+    ],
+  };
+
+  const dex = new Dex(dexSrc);
+
+  test('resolves', () => {
+    const gen1 = dex.gens[Symbol.iterator]().next().value;
+    const specie = gen1.species[Symbol.iterator]().next().value;
+    expect(specie.name).toBe('Charmander');
+    expect(specie.prevo).toBe(null);
+    expect(specie.evos[0].name).toBe('Charmeleon');
+  });
+});

--- a/src/test/ps-import.test.ts
+++ b/src/test/ps-import.test.ts
@@ -2,7 +2,7 @@ import psImport from '../ps-import';
 import path from 'path';
 
 describe('ps-import', () => {
-  const data = psImport(path.join(__dirname, '../../vendor/Pokemon-Showdown'));
+  const data = psImport(path.join(__dirname, '../../vendor/Pokemon-Showdown/data'));
   test('rby has the original 151', () => {
     expect(data.gens[1].species.length).toBe(151);
   });

--- a/src/test/ps-import.test.ts
+++ b/src/test/ps-import.test.ts
@@ -1,0 +1,9 @@
+import psImport from '../ps-import';
+import path from 'path';
+
+describe('ps-import', () => {
+  const data = psImport(path.join(__dirname, '../../vendor/Pokemon-Showdown'));
+  test('rby has the original 151', () => {
+    expect(data.gens[1].species.length).toBe(151);
+  });
+});

--- a/src/tools/convert-ps-data.ts
+++ b/src/tools/convert-ps-data.ts
@@ -16,5 +16,6 @@ const data = psImport(psDataDir);
 
 for (const gen of GENERATIONS) {
   const genData = data.gens[gen];
+  fs.mkdirSync(exportDir, { recursive: true });
   fs.writeFileSync(path.join(exportDir, `${gen}.json`), detStringify(genData, { space: '  ' }));
 }

--- a/src/tools/convert-ps-data.ts
+++ b/src/tools/convert-ps-data.ts
@@ -1,0 +1,20 @@
+import path from 'path';
+import fs from 'fs';
+import psImport from '../ps-import';
+import { GENERATIONS } from '../gens';
+// @ts-ignore
+import detStringify from 'json-stringify-deterministic';
+
+const [, , psDataDir, exportDir] = process.argv;
+
+if (psDataDir === undefined || exportDir === undefined) {
+  console.error('convert-ps-data <ps data dir> <export dir>');
+  process.exit(1);
+}
+
+const data = psImport(psDataDir);
+
+for (const gen of GENERATIONS) {
+  const genData = data.gens[gen];
+  fs.writeFileSync(path.join(exportDir, `${gen}.json`), detStringify(genData, { space: '  ' }));
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "extends": "./node_modules/gts/tsconfig-google.json",
-  "exclude": ["build"],
+  "exclude": ["build", "vendor"],
   "compilerOptions": {
     "incremental": true,
     "esModuleInterop": true,
-    "outDir": "./build"
+    "outDir": "./build",
+    "pretty": null,
   }
 }

--- a/tslint-semantic.json
+++ b/tslint-semantic.json
@@ -1,11 +1,14 @@
 {
+  "linterOptions": {
+    "exclude": ["build", "vendor"]
+  },
   "rules": {
     "await-promise": true,
     "ban-comma-operator": true,
     "no-async-without-await": true,
     "no-floating-promises": true,
     "no-for-in-array": true,
-    "no-implicit-dependencies": true,
+    "no-implicit-dependencies": [true, "dev"],
     "no-invalid-template-strings": true,
     "no-promise-as-boolean": true,
     "no-switch-case-fall-through": true,

--- a/tslint.json
+++ b/tslint.json
@@ -12,6 +12,8 @@
       }
     },
     "switch-default": false,
-    "variable-name": false
+    "variable-name": false,
+    "no-default-export": false,
+    "ban-ts-ignore": false
   }
 }


### PR DESCRIPTION
This commit adds:
- "Plain" and "Rich" interfaces to game objects
- Loading fundamentals
- Import code from the current PS data format, and a CLI tool to generate JSON in the plain format
- Some tweaks to tsconfig/tslint config

Bikeshedding:
- I adopt the name `Dex` to refer to a collection of generations.

Notes:
- A `Dex` from the lazy impl is essentially a transformer from Plain to Rich. This implementation does not maintain global state, you supply the `Dex` constructor with loaded plain objects, which can come from inline objects for testing, JSON on your disk, a web resource, etc.
- You are allowed to mutate the input to a `Dex`, just don't remove information that is already present. This is intended to be used to implement loading slices. Accessing a reference before the data referred to is loaded will throw an error.
- According to some light JSPerf testing, getters are as fast as regular property access. The classes in `dex-lazy-impl` could be changed to not copy any fields, instead using getters to access the source.

Things I considered out of scope for this PR:
- Convenience methods to create a Dex from a URL/fs path/etc
- Anything related to indexing, such as ID lookup
- Reducing duplication between plain and rich interfaces
- Generating human readable output
